### PR TITLE
[UPD] clarify how to skip the next command

### DIFF
--- a/rules/OPL/gpsr_en.md
+++ b/rules/OPL/gpsr_en.md
@@ -79,7 +79,11 @@ The score also changes based on the difficulty of the category.
 ### Skipping Commands
 
 The robot performs the command phase and service phase for three (3) times.
-However, the competing team cannot skip to the next command if no points where obtained during each task.
+However, the competing team is able to skip to the next command if the robot misunderstood the given command by the host.
+In order to demonstrate so, the robot needs to complete the mistaken task, and go back to the host position requesting for another task.
+
+> [!WARNING]
+> Teams may not take advantage of this rule to skip commands until their desired command is given.
 
 ### Command Generator
 

--- a/rules/OPL/gpsr_ja.md
+++ b/rules/OPL/gpsr_ja.md
@@ -77,8 +77,12 @@
 
 ### コマンドのスキップ (Skipping Commands)
 
-The robot performs the command phase and service phase for three (3) times.
-However, the competing team cannot skip to the next command if no points where obtained during each task.
+ロボットは`コマンドフェーズ`と`サービスフェーズ`を3回行う．
+ただし，ロボットがホストから与えられたコマンドを誤認識した場合，競技チームは次のコマンドにスキップすることができる．
+ロボットが誤認識したことを示すためには，ロボットは間違ったタスクを完了させ，ホストの位置に戻って，次のコマンドを要求する必要がある．
+
+> [!WARNING]
+> チームはこのルールを悪用して，希望のコマンドが与えられるまでコマンドをスキップすることはできない．
 
 ### コマンドジェネレータ (Command Generator)
 


### PR DESCRIPTION
- Clarify that only command skipping is allowed if the robot misunderstood the previously given command
Reference: https://github.com/RoboCupAtHomeJP/AtHome2024/issues/11