### PR TITLE
[FIX] Sentence Structure for Navigation task (DEM command only)

### DIFF
--- a/rules/OPL/gpsr_en.md
+++ b/rules/OPL/gpsr_en.md
@@ -131,7 +131,7 @@ If restart is decided to be done:
 | **Manipulation** <br>grasp, give\|place            | &bullet; Go to the `$ROOM`, grasp the `$OBJECT` on the `$PLACE` and place it on the `$PLACE`. <br>&bullet; Go to the `$ROOM`, grasp the `$OBJECT` on the `$PLACE` and give it to `$PERSON`. |
 | **Vision (Enumeration)** <br>count (obj \| people) | &bullet; Tell me how many `$CATEGORY_OBJ` there are on the `$PLACE`. <br>&bullet; Tell me how many people in the `$ROOM` are `$POSE/GESTURE`. |
 | **Vision (Description)** <br>find (obj \| person)  | &bullet; Tell me what is the `$OBJ_COMP` object on the `$PLACE`. <br>&bullet; Tell me the `$PERS_INFO` of the person at the `$PLACE` |
-| **Navigation** <br>follow, guide                   | &bullet; Go to the `$ROOM`, find `$PERSON` at the `$ROOM` and follow (him \| her). <br>&bullet; Go to the `$ROOM`, find `$PERSON` at the `$ROOM` and guide `(him\|her)` to the `$ROOM`. |
+| **Navigation** <br>follow, guide                   | &bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person at the `$ROOM` and follow (him \| her). <br>&bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person at the `$ROOM` and guide (him\|her) to the `$ROOM`. |
 | **Speech** <br>answer, tell                        | &bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and answer (his \| her) question. <br>&bullet; Go to the `$ROOM`, find the person who is `$POSE/GESTURE` and tell (him \| her) `$TELL_LIST`. |
 <!-- | **Speech** <br>answer, ask                         | &bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and answer (his \| her) question. <br>&bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and ask (him \| her) `$QUESTION`. | -->
 

--- a/rules/OPL/gpsr_en.md
+++ b/rules/OPL/gpsr_en.md
@@ -131,7 +131,7 @@ If restart is decided to be done:
 | **Manipulation** <br>grasp, give\|place            | &bullet; Go to the `$ROOM`, grasp the `$OBJECT` on the `$PLACE` and place it on the `$PLACE`. <br>&bullet; Go to the `$ROOM`, grasp the `$OBJECT` on the `$PLACE` and give it to `$PERSON`. |
 | **Vision (Enumeration)** <br>count (obj \| people) | &bullet; Tell me how many `$CATEGORY_OBJ` there are on the `$PLACE`. <br>&bullet; Tell me how many people in the `$ROOM` are `$POSE/GESTURE`. |
 | **Vision (Description)** <br>find (obj \| person)  | &bullet; Tell me what is the `$OBJ_COMP` object on the `$PLACE`. <br>&bullet; Tell me the `$PERS_INFO` of the person at the `$PLACE` |
-| **Navigation** <br>follow, guide                   | &bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person at the `$ROOM` and follow (him \| her). <br>&bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person at the `$ROOM` and guide (him\|her) to the `$ROOM`. |
+| **Navigation** <br>follow, guide                   | &bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person and follow (him \| her). <br>&bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person and guide (him\|her) to the `$ROOM`. |
 | **Speech** <br>answer, tell                        | &bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and answer (his \| her) question. <br>&bullet; Go to the `$ROOM`, find the person who is `$POSE/GESTURE` and tell (him \| her) `$TELL_LIST`. |
 <!-- | **Speech** <br>answer, ask                         | &bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and answer (his \| her) question. <br>&bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and ask (him \| her) `$QUESTION`. | -->
 

--- a/rules/OPL/gpsr_ja.md
+++ b/rules/OPL/gpsr_ja.md
@@ -130,7 +130,7 @@ Step 1を完了している場合，リスタート後に直前のタスクを�
 | **Manipulation** <br>grasp, give\|place            | &bullet; Go to the `$ROOM`, grasp the `$OBJECT` on the `$PLACE` and place it on the `$PLACE`. <br>&bullet; Go to the `$ROOM`, grasp the `$OBJECT` on the `$PLACE` and give it to `$PERSON`. |
 | **Vision (Enumeration)** <br>count (obj \| people) | &bullet; Tell me how many `$CATEGORY_OBJ` there are on the `$PLACE`. <br>&bullet; Tell me how many people in the `$ROOM` are `$POSE/GESTURE`. |
 | **Vision (Description)** <br>find (obj \| person)  | &bullet; Tell me what is the `$OBJ_COMP` object on the `$PLACE`. <br>&bullet; Tell me the `$PERS_INFO` of the person at the `$PLACE` |
-| **Navigation** <br>follow, guide                   | &bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person at the `$ROOM` and follow (him \| her). <br>&bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person at the `$ROOM` and guide (him\|her) to the `$ROOM`. |
+| **Navigation** <br>follow, guide                   | &bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person and follow (him \| her). <br>&bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person and guide (him\|her) to the `$ROOM`. |
 | **Speech** <br>answer, tell                        | &bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and answer (his \| her) question. <br>&bullet; Go to the `$ROOM`, find the person who is `$POSE/GESTURE` and tell (him \| her) `$TELL_LIST`. |
 <!-- | **Speech** <br>answer, ask                         | &bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and answer (his \| her) question. <br>&bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and ask (him \| her) `$QUESTION`. | -->
 

--- a/rules/OPL/gpsr_ja.md
+++ b/rules/OPL/gpsr_ja.md
@@ -130,7 +130,7 @@ Step 1を完了している場合，リスタート後に直前のタスクを�
 | **Manipulation** <br>grasp, give\|place            | &bullet; Go to the `$ROOM`, grasp the `$OBJECT` on the `$PLACE` and place it on the `$PLACE`. <br>&bullet; Go to the `$ROOM`, grasp the `$OBJECT` on the `$PLACE` and give it to `$PERSON`. |
 | **Vision (Enumeration)** <br>count (obj \| people) | &bullet; Tell me how many `$CATEGORY_OBJ` there are on the `$PLACE`. <br>&bullet; Tell me how many people in the `$ROOM` are `$POSE/GESTURE`. |
 | **Vision (Description)** <br>find (obj \| person)  | &bullet; Tell me what is the `$OBJ_COMP` object on the `$PLACE`. <br>&bullet; Tell me the `$PERS_INFO` of the person at the `$PLACE` |
-| **Navigation** <br>follow, guide                   | &bullet; Go to the `$ROOM`, find `$PERSON` at the `$ROOM` and follow (him \| her). <br>&bullet; Go to the `$ROOM`, find `$PERSON` at the `$ROOM` and guide `(him\|her)` to the `$ROOM`. |
+| **Navigation** <br>follow, guide                   | &bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person at the `$ROOM` and follow (him \| her). <br>&bullet; Go to the `$ROOM`, find `$POSE/GESTURE` person at the `$ROOM` and guide (him\|her) to the `$ROOM`. |
 | **Speech** <br>answer, tell                        | &bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and answer (his \| her) question. <br>&bullet; Go to the `$ROOM`, find the person who is `$POSE/GESTURE` and tell (him \| her) `$TELL_LIST`. |
 <!-- | **Speech** <br>answer, ask                         | &bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and answer (his \| her) question. <br>&bullet; Go to the `$ROOM`, find `$PERSON` at the `$PLACE` and ask (him \| her) `$QUESTION`. | -->
 


### PR DESCRIPTION
## Fix DEM Sentence Structure command
- `Navigation` task is updated as person cannot be identified with the current Sentence Structure

``` diff
- Go to the `$ROOM`, find `$PERSON` at the `$ROOM` and follow (him \| her).
+ Go to the `$ROOM`, find `$POSE/GESTURE` person  and follow (him \| her).
```
Example: Go to the living room, find  squatting person  and follow him .

``` diff
- Go to the `$ROOM`, find `$PERSON` at the `$ROOM` and guide (him\|her) to the `$ROOM`.
+ Go to the `$ROOM`, find `$POSE/GESTURE` person and guide (him\|her) to the `$ROOM`.
```
Example: Go to the living room, find squatting person and guide her to the dining room.